### PR TITLE
Remove console log from PageComposer

### DIFF
--- a/PageComposer.jsx
+++ b/PageComposer.jsx
@@ -23,7 +23,6 @@ export default function PageComposer({
   onClearLines,
   onGoToPrint,
 }) {
-  console.log("Aktualne lines:", lines.map(l=>l.map(a=>a.char).join("")));
   const [pageW, setPageW] = useState(A4_WIDTH);
   const wrapperRef = useRef();
 


### PR DESCRIPTION
## Summary
- remove console.log that logged current lines

## Testing
- `grep -n "Aktualne" -n PageComposer.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68643a590f1c8320a20af06e23f3406a