### PR TITLE
Reposition navigation controls to screen corners

### DIFF
--- a/PageComposer.jsx
+++ b/PageComposer.jsx
@@ -316,13 +316,12 @@ export default function PageComposer({
             </div>
           )}
         </div>
-        {/* Panel boczny po PRAWEJ */}
+        {/* Przyciski nawigacyjne */}
         <div
           style={{
             position: "absolute",
             right: 10,
-            top: "50%",
-            transform: "translateY(-50%)",
+            bottom: 10,
             zIndex: 10,
             display: "flex",
             flexDirection: "column",
@@ -353,46 +352,17 @@ export default function PageComposer({
             </span>
           </button>
         </div>
-        {/* Panel boczny (lewy) */}
         <div
           style={{
             position: "absolute",
             left: 10,
-            top: "50%",
-            transform: "translateY(-50%)",
+            bottom: 10,
             zIndex: 10,
             display: "flex",
             flexDirection: "column",
-            gap: 0,
+            gap: 10,
           }}
         >
-          <button
-            onClick={onBack}
-            style={{
-              background: "#222",
-              color: "#fff",
-              border: "2px solid #888",
-              borderRadius: "10%",
-              width: 30,
-              height: 30,
-              fontSize: 14,
-              cursor: "pointer",
-              marginBottom: 10,
-              boxShadow: "2px 2px 8px #0002",
-              outline: "none",
-            }}
-            title="Powrót do składu zecerskiego"
-            aria-label="Powrót do składu zecerskiego"
-          >
-            <span
-              style={{
-                display: "inline-block",
-                transform: "rotate(180deg) translateY(2px)",
-              }}
-            >
-              &#8594;
-            </span>
-          </button>
           <button
             onClick={onClearLines}
             style={{
@@ -417,6 +387,32 @@ export default function PageComposer({
               }}
             >
               &#128465;
+            </span>
+          </button>
+          <button
+            onClick={onBack}
+            style={{
+              background: "#222",
+              color: "#fff",
+              border: "2px solid #888",
+              borderRadius: "10%",
+              width: 30,
+              height: 30,
+              fontSize: 14,
+              cursor: "pointer",
+              boxShadow: "2px 2px 8px #0002",
+              outline: "none",
+            }}
+            title="Powrót do składu zecerskiego"
+            aria-label="Powrót do składu zecerskiego"
+          >
+            <span
+              style={{
+                display: "inline-block",
+                transform: "rotate(180deg) translateY(2px)",
+              }}
+            >
+              &#8594;
             </span>
           </button>
         </div>

--- a/PrintModule.jsx
+++ b/PrintModule.jsx
@@ -179,11 +179,13 @@ export default function PrintModule({ lines, onBack }) {
             </div>
           </div>
         </div>
-        {/* Przykładowy przycisk powrotu (możesz przenieść do bocznego panelu lub stopki) */}
+        {/* Przycisk powrotu */}
         <button
           onClick={onBack}
           style={{
-            margin: "30px auto 0 auto",
+            position: "absolute",
+            left: 10,
+            bottom: 10,
             background: "#222",
             color: "#fff",
             border: "2px solid #888",
@@ -194,7 +196,7 @@ export default function PrintModule({ lines, onBack }) {
             cursor: "pointer",
             boxShadow: "2px 2px 8px #0002",
             outline: "none",
-            display: "block"
+            zIndex: 10,
           }}
           title="Powrót"
           aria-label="Powrót"


### PR DESCRIPTION
## Summary
- Move forward and back arrows to bottom-right and bottom-left respectively in PageComposer
- Place trash icon just above the back arrow
- Anchor print module's back arrow to bottom-left for consistent navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e1419c6c8320a47e1048119556bd