### PR TITLE
Reposition navigation buttons

### DIFF
--- a/LetterComposer.jsx
+++ b/LetterComposer.jsx
@@ -399,9 +399,15 @@ export default function LetterComposer({ onMoveLineToPage }) {
             title="Przenieś linię na stronę"
             aria-label="Przenieś linię na stronę"
           >
-            <span style={{ display: "inline-block", transform: "translateY(0px)" }}>
-              &#8594;
-            </span>
+          <span
+            style={{
+              display: "inline-block",
+              transform: "translateY(0px)",
+              fontFamily: "Arial, sans-serif",
+            }}
+          >
+            &#8594;
+          </span>
           </button>
         </div>
         {renderGhostLetter()}

--- a/LetterComposer.jsx
+++ b/LetterComposer.jsx
@@ -252,18 +252,19 @@ export default function LetterComposer({ onMoveLineToPage }) {
       }}
     >
       {/* GŁÓWNY BLOK */}
-      <div
-        style={{
-          flex: "1 1 auto",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          minHeight: 0,
-          width: "100%",
-          overflow: "hidden"
-        }}
-      >
+        <div
+          style={{
+            flex: "1 1 auto",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: 0,
+            width: "100%",
+            overflow: "hidden",
+            position: "relative",
+          }}
+        >
         {/* Kaszta */}
         <div
           ref={kasztaRef}
@@ -326,14 +327,15 @@ export default function LetterComposer({ onMoveLineToPage }) {
             />
           ))}
         </div>
-        {/* Wierszownik + GUZIK PO PRAWEJ */}
-        <div style={{
-          display: "flex",
-          alignItems: "center",
-          width: "100%",
-          justifyContent: "center",
-          marginTop: 0
-        }}>
+        {/* Wierszownik */}
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "center",
+            marginTop: 0,
+          }}
+        >
           <div
             ref={wierszownikRef}
             style={{
@@ -343,7 +345,7 @@ export default function LetterComposer({ onMoveLineToPage }) {
               margin: "1px auto 0px auto",
               touchAction: "none",
               flexShrink: 0,
-              boxSizing: "border-box"
+              boxSizing: "border-box",
             }}
           >
             <img
@@ -353,43 +355,53 @@ export default function LetterComposer({ onMoveLineToPage }) {
                 width: "100%",
                 height: "100%",
                 display: "block",
-                pointerEvents: "none"
+                pointerEvents: "none",
               }}
             />
             {renderLettersOnLine()}
           </div>
-          {/* GUZIK PRZENIESIENIA LINII */}
+        </div>
+        {/* Panel boczny po PRAWEJ */}
+        <div
+          style={{
+            position: "absolute",
+            right: 10,
+            bottom: 70,
+            zIndex: 10,
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
           <button
+            onClick={() => {
+              const line = slots.filter(Boolean);
+              if (typeof onMoveLineToPage === "function") {
+                onMoveLineToPage(line);
+                setSlots(Array(SLOTS_COUNT).fill(null));
+              }
+            }}
             style={{
-              
-              marginRight: 10,
-              height: 30,
-              width: 30,
-              borderRadius: "15%",
               background: "#222",
-              border: "2px solid #888",
               color: "#fff",
-              fontSize: 14,
+              border: "2px solid #888",
+              borderRadius: "10%",
+              width: 39,
+              height: 39,
+              fontSize: 24,
+              fontWeight: "bold",
               cursor: "pointer",
+              boxShadow: "2px 2px 8px #0002",
+              outline: "none",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              boxShadow: "1px 2px 8px #0002",
-              transition: "background 0.15s",
-              outline: "none"
             }}
-        onClick={() => {
-  const line = slots.filter(Boolean);
-  if (typeof onMoveLineToPage === "function") {
-    onMoveLineToPage(line); // nawet jak pusty
-    setSlots(Array(SLOTS_COUNT).fill(null));
-  }
-}}
-
             title="Przenieś linię na stronę"
             aria-label="Przenieś linię na stronę"
           >
-            <span style={{ display: "inline-block", transform: "translateY(0px)" }}>&#8594;</span>
+            <span style={{ display: "inline-block", transform: "translateY(0px)" }}>
+              &#8594;
+            </span>
           </button>
         </div>
         {renderGhostLetter()}

--- a/PageComposer.jsx
+++ b/PageComposer.jsx
@@ -364,7 +364,11 @@ export default function PageComposer({
             aria-label="Przejdź do druku"
           >
             <span
-              style={{ display: "inline-block", transform: "translateY(0px)" }}
+              style={{
+                display: "inline-block",
+                transform: "translateY(0px)",
+                fontFamily: "Arial, sans-serif",
+              }}
             >
               &#8594;
             </span>
@@ -403,6 +407,7 @@ export default function PageComposer({
               style={{
                 display: "inline-block",
                 transform: "rotate(20deg) translateX(-5px) ",
+                fontFamily: "Arial, sans-serif",
               }}
             >
               &#128465;
@@ -429,6 +434,7 @@ export default function PageComposer({
               style={{
                 display: "inline-block",
                 transform: "rotate(180deg) translateY(2px)",
+                fontFamily: "Arial, sans-serif",
               }}
             >
               &#8594;

--- a/PageComposer.jsx
+++ b/PageComposer.jsx
@@ -340,12 +340,10 @@ export default function PageComposer({
           style={{
             position: "absolute",
             right: 10,
-            top: "50%",
-            transform: "translateY(-50%)",
+            bottom: 70,
             zIndex: 10,
             display: "flex",
             flexDirection: "column",
-            gap: 1,
           }}
         >
           <button
@@ -355,9 +353,9 @@ export default function PageComposer({
               color: "#fff",
               border: "2px solid #888",
               borderRadius: "10%",
-              width: 30,
-              height: 30,
-              fontSize: 14,
+              width: 39,
+              height: 39,
+              fontSize: 18,
               cursor: "pointer",
               boxShadow: "2px 2px 8px #0002",
               outline: "none",
@@ -377,41 +375,13 @@ export default function PageComposer({
           style={{
             position: "absolute",
             left: 10,
-            top: "50%",
-            transform: "translateY(-50%)",
+            bottom: 70,
             zIndex: 10,
             display: "flex",
             flexDirection: "column",
-            gap: 0,
+            gap: 10,
           }}
         >
-          <button
-            onClick={onBack}
-            style={{
-              background: "#222",
-              color: "#fff",
-              border: "2px solid #888",
-              borderRadius: "10%",
-              width: 30,
-              height: 30,
-              fontSize: 14,
-              cursor: "pointer",
-              marginBottom: 10,
-              boxShadow: "2px 2px 8px #0002",
-              outline: "none",
-            }}
-            title="Powrót do składu zecerskiego"
-            aria-label="Powrót do składu zecerskiego"
-          >
-            <span
-              style={{
-                display: "inline-block",
-                transform: "rotate(180deg) translateY(2px)",
-              }}
-            >
-              &#8594;
-            </span>
-          </button>
           <button
             onClick={onClearLines}
             style={{
@@ -419,9 +389,9 @@ export default function PageComposer({
               color: "#fff",
               border: "2px  solid #ff0000",
               borderRadius: "10%",
-              width: 30,
-              height: 30,
-              fontSize: 14,
+              width: 39,
+              height: 39,
+              fontSize: 18,
               cursor: "pointer",
               boxShadow: "2px 2px 8px #0002",
               outline: "none",
@@ -436,6 +406,32 @@ export default function PageComposer({
               }}
             >
               &#128465;
+            </span>
+          </button>
+          <button
+            onClick={onBack}
+            style={{
+              background: "#222",
+              color: "#fff",
+              border: "2px solid #888",
+              borderRadius: "10%",
+              width: 39,
+              height: 39,
+              fontSize: 18,
+              cursor: "pointer",
+              boxShadow: "2px 2px 8px #0002",
+              outline: "none",
+            }}
+            title="Powrót do składu zecerskiego"
+            aria-label="Powrót do składu zecerskiego"
+          >
+            <span
+              style={{
+                display: "inline-block",
+                transform: "rotate(180deg) translateY(2px)",
+              }}
+            >
+              &#8594;
             </span>
           </button>
         </div>

--- a/PrintModule.jsx
+++ b/PrintModule.jsx
@@ -47,18 +47,19 @@ export default function PrintModule({ lines, onBack }) {
         boxSizing: "border-box"
       }}
     >
-      <div
-        style={{
-          flex: "1 1 auto",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          minHeight: 0,
-          width: "100%",
-          overflow: "hidden"
-        }}
-      >
+        <div
+          style={{
+            flex: "1 1 auto",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: 0,
+            width: "100%",
+            overflow: "hidden",
+            position: "relative",
+          }}
+        >
         <div
           style={{
             display: "flex",
@@ -182,30 +183,43 @@ export default function PrintModule({ lines, onBack }) {
             </div>
           </div>
         </div>
-        {/* Przykładowy przycisk powrotu (możesz przenieść do bocznego panelu lub stopki) */}
-        <button
-          onClick={onBack}
+        {/* Panel boczny (lewy) */}
+        <div
           style={{
-            margin: "30px auto 0 auto",
-            background: "#222",
-            color: "#fff",
-            border: "2px solid #888",
-            borderRadius: "10%",
-            width: 30,
-            height: 30,
-            fontSize: 13,
-            cursor: "pointer",
-            boxShadow: "2px 2px 8px #0002",
-            outline: "none",
-            display: "block"
+            position: "absolute",
+            left: 10,
+            bottom: 70,
+            zIndex: 10,
+            display: "flex",
+            flexDirection: "column",
           }}
-          title="Powrót"
-          aria-label="Powrót"
         >
-          <span style={{ display: "inline-block", transform: "rotate(180deg) translateY(2px)" }}>
-            &#8594;
-          </span>
-        </button>
+          <button
+            onClick={onBack}
+            style={{
+              background: "#222",
+              color: "#fff",
+              border: "2px solid #888",
+              borderRadius: "10%",
+              width: 39,
+              height: 39,
+              fontSize: 24,
+              fontWeight: "bold",
+              cursor: "pointer",
+              boxShadow: "2px 2px 8px #0002",
+              outline: "none",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+            title="Powrót"
+            aria-label="Powrót"
+          >
+            <span style={{ display: "inline-block", transform: "rotate(180deg) translateY(2px)" }}>
+              &#8594;
+            </span>
+          </button>
+        </div>
       </div>
       {/* STOPKA */}
       <p

--- a/PrintModule.jsx
+++ b/PrintModule.jsx
@@ -215,9 +215,15 @@ export default function PrintModule({ lines, onBack }) {
             title="Powrót"
             aria-label="Powrót"
           >
-            <span style={{ display: "inline-block", transform: "rotate(180deg) translateY(2px)" }}>
-              &#8594;
-            </span>
+          <span
+            style={{
+              display: "inline-block",
+              transform: "rotate(180deg) translateY(2px)",
+              fontFamily: "Arial, sans-serif",
+            }}
+          >
+            &#8594;
+          </span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Move navigation buttons to page corners
- Place trash button above back arrow and enlarge all buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e40cbc188320a312062d3a53d5fa