### PR TITLE
Add admin panel with password access

### DIFF
--- a/AdminPanel.jsx
+++ b/AdminPanel.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+export default function AdminPanel({ onCalibrate }) {
+  return (
+    <div style={{ textAlign: "center", padding: "100px" }}>
+      <h2
+        style={{
+          fontFamily: "GrohmanGrotesk-Classic",
+          fontSize: "2rem",
+          color: "#000",
+        }}
+      >
+        Panel administracyjny
+      </h2>
+      <h3
+        style={{
+          fontFamily: "GrohmanGrotesk-Classic",
+          fontSize: "1.66rem",
+          color: "#000",
+        }}
+      >
+        Wybierz kasztę do kalibracji:
+      </h3>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          gap: "2rem",
+          marginTop: "1rem",
+        }}
+      >
+        <img
+          src="/assets/kaszta.png"
+          alt="Kaszta"
+          style={{ width: "400px", cursor: "pointer" }}
+          onClick={() => onCalibrate("kaszta")}
+        />
+        <img
+          src="/assets/kaszta_szuflada.png"
+          alt="Kaszta szuflada"
+          style={{ width: "400px", cursor: "pointer" }}
+          onClick={() => onCalibrate("szuflada")}
+        />
+      </div>
+    </div>
+  );
+}
+

--- a/App.jsx
+++ b/App.jsx
@@ -3,6 +3,8 @@ import LetterComposer from "./LetterComposer";
 import PageComposer from "./PageComposer";
 import PrintModule from "./PrintModule";
 import Intro from "./Intro";
+import AdminPanel from "./AdminPanel";
+import LetterFieldGenerator from "./LetterFieldGenerator";
 
 export default function App() {
   // Każdy ciąg znaków z wierszownika to tablica liter (obiektów), np. [{char, img, width}]
@@ -18,6 +20,15 @@ export default function App() {
   function handleSelect(variant) {
     setKasztaVariant(variant);
     setModule("letter");
+  }
+
+  function handleAdminLogin() {
+    setModule("admin");
+  }
+
+  function handleCalibrate(variant) {
+    setKasztaVariant(variant);
+    setModule("calibrate");
   }
  // const [module, setModule] = useState("page");
 
@@ -35,7 +46,8 @@ export default function App() {
 
   return (
     <>
-      {module === "intro" && <Intro onSelect={handleSelect} />}
+      {module === "intro" && <Intro onSelect={handleSelect} onAdmin={handleAdminLogin} />}
+      {module === "admin" && <AdminPanel onCalibrate={handleCalibrate} />}
       {module === "letter" && (
         <LetterComposer
           onMoveLineToPage={line => {
@@ -58,11 +70,17 @@ export default function App() {
 )}
 
       {module === "print" && (
-  <PrintModule
-    lines={lines}
-    onBack={() => setModule("page")}
-  />
-)}
+        <PrintModule
+          lines={lines}
+          onBack={() => setModule("page")}
+        />
+      )}
+      {module === "calibrate" && (
+        <LetterFieldGenerator
+          kasztaImage={kasztaSettings[kasztaVariant].image}
+          onBack={() => setModule("admin")}
+        />
+      )}
 
     </>
   );

--- a/Intro.jsx
+++ b/Intro.jsx
@@ -1,14 +1,60 @@
 import React from "react";
 
-export default function Intro({ onSelect }) {
-  return (
+export default function Intro({ onSelect, onAdmin }) {
+  function handleAdminClick() {
+    const pwd = window.prompt("Podaj hasło:");
+    if (pwd === "mask") {
+      onAdmin && onAdmin();
+    } else if (pwd !== null) {
+      window.alert("Nieprawidłowe hasło");
+    }
+  }
 
-    <div style={{ textAlign: "center", padding: "100px" }}>
-      <h1 style={{ fontFamily: "GrohmanGrotesk-Classic", fontSize: "223px" , color:"#FFF" , height: "100px" }}> ZECER </h1>
-      <h2 style={{ fontFamily: "GrohmanGrotesk-Classic", fontSize: "6.66rem"  , color:"#ff0000"}}>MUZEUM KSIĄŻKI ARTYSTYCZNEJ</h2>
- 
- <h3 style={{ fontFamily: "GrohmanGrotesk-Classic", fontSize: "1.66rem"  , color:"#000"}}>WYBIERZ SWOJĄ KASZTĘ:</h3>
-      
+  return (
+    <div style={{ textAlign: "center", padding: "100px", position: "relative" }}>
+      <button
+        onClick={handleAdminClick}
+        style={{
+          position: "absolute",
+          top: 10,
+          right: 10,
+          background: "transparent",
+          border: "none",
+          color: "#fff",
+          cursor: "pointer",
+          fontSize: "16px",
+        }}
+      >
+        p
+      </button>
+      <h1
+        style={{
+          fontFamily: "GrohmanGrotesk-Classic",
+          fontSize: "223px",
+          color: "#FFF",
+          height: "100px",
+        }}
+      >
+        ZECER
+      </h1>
+      <h2
+        style={{
+          fontFamily: "GrohmanGrotesk-Classic",
+          fontSize: "6.66rem",
+          color: "#ff0000",
+        }}
+      >
+        MUZEUM KSIĄŻKI ARTYSTYCZNEJ
+      </h2>
+      <h3
+        style={{
+          fontFamily: "GrohmanGrotesk-Classic",
+          fontSize: "1.66rem",
+          color: "#000",
+        }}
+      >
+        WYBIERZ SWOJĄ KASZTĘ:
+      </h3>
       <div
         style={{
           display: "flex",
@@ -33,3 +79,4 @@ export default function Intro({ onSelect }) {
     </div>
   );
 }
+

--- a/LetterFieldGenerator.jsx
+++ b/LetterFieldGenerator.jsx
@@ -11,7 +11,7 @@ const ALFABET = [
 const KASZTA_WIDTH = 1618;
 const KASZTA_HEIGHT = 1080;
 
-export default function LetterFieldGenerator() {
+export default function LetterFieldGenerator({ kasztaImage = "/assets/kaszta.png", onBack }) {
   const [mode, setMode] = useState("male");  // "male" lub "wielkie"
   const [step, setStep] = useState(0);       // 0: pierwszy klik, 1: drugi klik
   const [clicks, setClicks] = useState([]);
@@ -73,6 +73,11 @@ export default function LetterFieldGenerator() {
 
 return (
   <div style={{ maxWidth: 1080 }}>
+    {onBack && (
+      <button onClick={onBack} style={{ marginBottom: 16 }}>
+        Powrót
+      </button>
+    )}
     <div style={{ marginBottom: 16 }}>
       <span className="text-lg">
         Kliknij dwa narożniki pola dla <b>{isMale ? "małej" : "wielkiej"}</b> litery:{" "}
@@ -102,7 +107,7 @@ return (
       onClick={handleKasztaClick}
     >
       <img
-        src="/assets/kaszta.png"
+        src={kasztaImage}
         alt="Kaszta"
         width={KASZTA_WIDTH}
         height={KASZTA_HEIGHT}


### PR DESCRIPTION
## Summary
- Add small "p" login in Intro that prompts for password and opens admin panel
- Introduce admin panel allowing kaszta selection and calibration mode
- Enhance LetterFieldGenerator to accept custom kaszta images and provide a back button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b66fbb65bc832095be31298da04cd1