### PR TITLE
Align letter scaling across modules

### DIFF
--- a/PageComposer.jsx
+++ b/PageComposer.jsx
@@ -5,10 +5,13 @@ const A4_HEIGHT = 1123;
 const SHEET_OFFSET_RIGHT = 120;
 const SHEET_OFFSET_TOP = 170;
 const LETTER_BASE_HEIGHT = 96;
+const LETTER_SCALE = 0.5;
 
 const getLineHeight = (line) => {
   if (!line || line.length === 0) return LETTER_BASE_HEIGHT;
-  return Math.max(...line.map((l) => l.height || LETTER_BASE_HEIGHT));
+  return Math.max(
+    ...line.map((l) => (l.height ? l.height * LETTER_SCALE : LETTER_BASE_HEIGHT))
+  );
 };
 
 
@@ -292,13 +295,17 @@ export default function PageComposer({
                 onMouseDown={(e) => handleDragStart(i, e)}
                 onTouchStart={(e) => handleDragStart(i, e)}
               >
-                {line.map((letter, j) => (
+                  {line.map((letter, j) => (
                   <img
                     key={j}
                     src={letter.img}
                     alt={letter.char}
-                    width={letter.width * scale}
-                    height={(letter.height || LETTER_BASE_HEIGHT) * scale}
+                    width={letter.width * LETTER_SCALE * scale}
+                    height={
+                      (letter.height
+                        ? letter.height * LETTER_SCALE
+                        : LETTER_BASE_HEIGHT) * scale
+                    }
                     style={{ marginLeft: 0, pointerEvents: "none" }}
                     draggable={false}
                   />
@@ -332,8 +339,12 @@ export default function PageComposer({
                   key={j}
                   src={letter.img}
                   alt={letter.char}
-                  width={letter.width * scale}
-                  height={(letter.height || LETTER_BASE_HEIGHT) * scale}
+                  width={letter.width * LETTER_SCALE * scale}
+                  height={
+                    (letter.height
+                      ? letter.height * LETTER_SCALE
+                      : LETTER_BASE_HEIGHT) * scale
+                  }
                   style={{ marginLeft: 0, pointerEvents: "none" }}
                   draggable={false}
                 />

--- a/PageComposer.jsx
+++ b/PageComposer.jsx
@@ -4,8 +4,12 @@ const A4_WIDTH = 796;
 const A4_HEIGHT = 1123;
 const SHEET_OFFSET_RIGHT = 120;
 const SHEET_OFFSET_TOP = 170;
-const LETTER_SCALE = 2;
-const LETTER_BASE_HEIGHT = 96 / 3;
+const LETTER_BASE_HEIGHT = 96;
+
+const getLineHeight = (line) => {
+  if (!line || line.length === 0) return LETTER_BASE_HEIGHT;
+  return Math.max(...line.map((l) => l.height || LETTER_BASE_HEIGHT));
+};
 
 
 
@@ -188,7 +192,7 @@ export default function PageComposer({
       return {
         background: "#e3f2ff",
         borderRadius: 4 * scale,
-        minHeight: LETTER_BASE_HEIGHT * LETTER_SCALE * scale,
+        minHeight: getLineHeight(lines[i]) * scale,
         outline: "2px dashed #28b0ef",
         transition: "background 0.12s",
       };
@@ -266,6 +270,7 @@ export default function PageComposer({
         >
           {lines.map((line, i) => {
             const isHidden = dragIndex === i;
+            const lineHeight = getLineHeight(line);
             return (
               <div
                 className="line-draggable"
@@ -277,7 +282,7 @@ export default function PageComposer({
                   alignItems: "flex-end",
                   justifyContent: "flex-end",
                   margin: `0 0 ${8 * scale}px 0`,
-                  minHeight: LETTER_BASE_HEIGHT * LETTER_SCALE * scale,
+                  minHeight: lineHeight * scale,
                   maxWidth: `calc(100% - ${sheetOffsetRight}px)`,
                   cursor: dragIndex === null ? "grab" : "default",
                   userSelect: "none",
@@ -292,8 +297,8 @@ export default function PageComposer({
                     key={j}
                     src={letter.img}
                     alt={letter.char}
-                    width={(letter.width / 3) * scale * LETTER_SCALE}
-                    height={LETTER_BASE_HEIGHT * scale * LETTER_SCALE}
+                    width={letter.width * scale}
+                    height={(letter.height || LETTER_BASE_HEIGHT) * scale}
                     style={{ marginLeft: 0, pointerEvents: "none" }}
                     draggable={false}
                   />
@@ -319,6 +324,7 @@ export default function PageComposer({
                 transform: "scale(1.03)",
                 background: "#e4ecf4",
                 borderRadius: 4 * scale,
+                minHeight: getLineHeight(lines[dragIndex]) * scale,
               }}
             >
               {lines[dragIndex].map((letter, j) => (
@@ -326,8 +332,8 @@ export default function PageComposer({
                   key={j}
                   src={letter.img}
                   alt={letter.char}
-                  width={(letter.width / 3) * scale * LETTER_SCALE}
-                  height={LETTER_BASE_HEIGHT * scale * LETTER_SCALE}
+                  width={letter.width * scale}
+                  height={(letter.height || LETTER_BASE_HEIGHT) * scale}
                   style={{ marginLeft: 0, pointerEvents: "none" }}
                   draggable={false}
                 />

--- a/PrintModule.jsx
+++ b/PrintModule.jsx
@@ -3,10 +3,13 @@ import React, { useEffect, useState } from "react";
 const A4_WIDTH = 796;
 const A4_HEIGHT = 1123;
 const BASE_LETTER_HEIGHT = 96;
+const LETTER_SCALE = 0.5;
 
 const getLineHeight = (line) => {
   if (!line || line.length === 0) return BASE_LETTER_HEIGHT;
-  return Math.max(...line.map((l) => l.height || BASE_LETTER_HEIGHT));
+  return Math.max(
+    ...line.map((l) => (l.height ? l.height * LETTER_SCALE : BASE_LETTER_HEIGHT))
+  );
 };
 
 export default function PrintModule({ lines, onBack }) {
@@ -155,8 +158,12 @@ export default function PrintModule({ lines, onBack }) {
                       key={j}
                       src={letter.img}
                       alt={letter.char}
-                      width={letter.width * scale}
-                      height={(letter.height || BASE_LETTER_HEIGHT) * scale}
+                      width={letter.width * LETTER_SCALE * scale}
+                      height={
+                        (letter.height
+                          ? letter.height * LETTER_SCALE
+                          : BASE_LETTER_HEIGHT) * scale
+                      }
                       style={{ marginLeft: 0 * scale }}
                       draggable={false}
                     />
@@ -225,8 +232,12 @@ export default function PrintModule({ lines, onBack }) {
                         key={j}
                         src={letter.img}
                         alt={letter.char}
-                        width={letter.width * scale}
-                        height={(letter.height || BASE_LETTER_HEIGHT) * scale}
+                        width={letter.width * LETTER_SCALE * scale}
+                        height={
+                          (letter.height
+                            ? letter.height * LETTER_SCALE
+                            : BASE_LETTER_HEIGHT) * scale
+                        }
                         draggable={false}
                       />
                     ))}

--- a/PrintModule.jsx
+++ b/PrintModule.jsx
@@ -2,6 +2,12 @@ import React, { useEffect, useState } from "react";
 
 const A4_WIDTH = 796;
 const A4_HEIGHT = 1123;
+const BASE_LETTER_HEIGHT = 96;
+
+const getLineHeight = (line) => {
+  if (!line || line.length === 0) return BASE_LETTER_HEIGHT;
+  return Math.max(...line.map((l) => l.height || BASE_LETTER_HEIGHT));
+};
 
 export default function PrintModule({ lines, onBack }) {
   const [pageW, setPageW] = useState(A4_WIDTH);
@@ -127,34 +133,37 @@ export default function PrintModule({ lines, onBack }) {
                 zIndex: 2
               }}
             />
-            {lines.map((line, i) => (
-              <div
-                key={i}
-                style={{
-                  position: "relative",
-                  zIndex: 1,
-                  display: "flex",
-                  flexDirection: "row",
-                  alignItems: "flex-start",
-                  justifyContent: "flex-end",
-                  margin: `${0 * scale}px 0 ${12 * scale}px 0`,
-                  minHeight: 96/3 * scale,
-                  maxWidth: "100%"
-                }}
-              >
-                {line.map((letter, j) => (
-                  <img
-                    key={j}
-                    src={letter.img}
-                    alt={letter.char}
-                    width={letter.width/3 * scale}
-                    height={96/3 * scale}
-                    style={{ marginLeft: 0 * scale }}
-                    draggable={false}
-                  />
-                ))}
-              </div>
-            ))}
+            {lines.map((line, i) => {
+              const lineHeight = getLineHeight(line);
+              return (
+                <div
+                  key={i}
+                  style={{
+                    position: "relative",
+                    zIndex: 1,
+                    display: "flex",
+                    flexDirection: "row",
+                    alignItems: "flex-start",
+                    justifyContent: "flex-end",
+                    margin: `${0 * scale}px 0 ${12 * scale}px 0`,
+                    minHeight: lineHeight * scale,
+                    maxWidth: "100%"
+                  }}
+                >
+                  {line.map((letter, j) => (
+                    <img
+                      key={j}
+                      src={letter.img}
+                      alt={letter.char}
+                      width={letter.width * scale}
+                      height={(letter.height || BASE_LETTER_HEIGHT) * scale}
+                      style={{ marginLeft: 0 * scale }}
+                      draggable={false}
+                    />
+                  ))}
+                </div>
+              );
+            })}
           </div>
           {/* Kartka A4 PRAWA (Lustrzane odbicie) */}
           <div
@@ -194,35 +203,36 @@ export default function PrintModule({ lines, onBack }) {
                 paddingLeft: 60 * scale
               }}
             >
-              {mirroredLines.map((line, i) => (
-                <div
-                  key={i}
-                  style={{
-                    transform: "scaleX(-1)",
-                    display: "flex",
-                    flexDirection: "row",
-                    alignItems: "flex-start",
-                    justifyContent: "flex-start",
-                    margin: `${0 * scale}px 0 ${12 * scale}px 0`,
-                    minHeight: 96/3 * scale,
-                    filter: "invert(1)",
-                    maxWidth: "100%"
-                  }}
-                >
-                  {[...line].map((letter, j) => (
-                    <img
-                      key={j}
-                      src={letter.img}
-                      alt={letter.char}
-                      width={letter.width/3 * scale}
-                      height={96/3 * scale}
-                    // style={{ filter: invert(1), }} 
-                      draggable={false}
-
-                    />
-                  ))}
-                </div>
-              ))}
+              {mirroredLines.map((line, i) => {
+                const lineHeight = getLineHeight(line);
+                return (
+                  <div
+                    key={i}
+                    style={{
+                      transform: "scaleX(-1)",
+                      display: "flex",
+                      flexDirection: "row",
+                      alignItems: "flex-start",
+                      justifyContent: "flex-start",
+                      margin: `${0 * scale}px 0 ${12 * scale}px 0`,
+                      minHeight: lineHeight * scale,
+                      filter: "invert(1)",
+                      maxWidth: "100%"
+                    }}
+                  >
+                    {[...line].map((letter, j) => (
+                      <img
+                        key={j}
+                        src={letter.img}
+                        alt={letter.char}
+                        width={letter.width * scale}
+                        height={(letter.height || BASE_LETTER_HEIGHT) * scale}
+                        draggable={false}
+                      />
+                    ))}
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- measure letter images to capture intrinsic width and height in LetterComposer for accurate proportions
- compute dynamic line heights and render letters using their natural sizes in PageComposer
- scale printed lines from intrinsic letter dimensions for consistent output in PrintModule

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/zecer/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c16d6120b48320ae97a8e2dd35c50c